### PR TITLE
Fix stopCurrentPlayback call

### DIFF
--- a/lib/playPlaylist.js
+++ b/lib/playPlaylist.js
@@ -76,7 +76,7 @@ export async function playPlaylist(startIndex, endIndex, sendResponse, tabId) {
 
         // 停止當前播放
         if (isPlaying) {
-            await stopCurrentPlayback();
+            await stopCurrentPlayback(tabId);
             await setStorageValue(`isPlaying_${tabId}`, false);
             console.debug('Stopped current playback and updated isPlaying to false');
         }


### PR DESCRIPTION
## Summary
- ensure stopCurrentPlayback receives tabId

## Testing
- `node -e "import('./lib/playPlaylist.js').then(()=>console.log('OK')).catch(err=>console.error(err))" --experimental-modules --es-module-specifier-resolution=node`

------
https://chatgpt.com/codex/tasks/task_e_683f72e7124c83288017dff4c2a5b624