### PR TITLE
Avoid recording timestamps without playlists

### DIFF
--- a/lib/mouseEventHandler.js
+++ b/lib/mouseEventHandler.js
@@ -117,26 +117,40 @@ export class MouseEventHandler {
       this.sharedState.state = getandUpdatePlaylistState(this.sharedState);
       if (this.stateManager) {
         this.stateManager.setState(this.sharedState.state);
-    this.stateManager.save();
-    // update playlist-level meta from DOM datasets after reorder
-    (async () => {
-      try {
-        if (typeof this.stateManager.saveMeta === 'function') {
-          const metaCandidates = this.sharedState.playlistItems.map(it => ({
-            lastModified: it.dataset?.lastModified || null,
-            uploadTime: it.dataset?.uploadTime || null
-          }));
-          const lmList = metaCandidates.map(m => m.lastModified).filter(Boolean).sort();
-          const utList = metaCandidates.map(m => m.uploadTime).filter(Boolean).sort();
-          const lastModified = lmList.length ? lmList.slice(-1)[0] : new Date().toISOString();
-          const uploadTime = utList.length ? utList[0] : new Date().toISOString();
-          const newMeta = { lastModified, uploadTime };
-          await this.stateManager.saveMeta(newMeta);
+        if (!this.sharedState.playlistItems || this.sharedState.playlistItems.length === 0) {
+          // remove storage for empty playlists
+          (async () => {
+            try {
+              const vid = this.stateManager.videoId || null;
+              if (vid) {
+                await chrome.storage.local.remove([`playlist_${vid}`, `playlist_meta_${vid}`]);
+              }
+            } catch (e) {
+              // ignore
+            }
+          })();
+        } else {
+          this.stateManager.save();
+          // update playlist-level meta from DOM datasets after reorder
+          (async () => {
+            try {
+              if (typeof this.stateManager.saveMeta === 'function') {
+                const metaCandidates = this.sharedState.playlistItems.map(it => ({
+                  lastModified: it.dataset?.lastModified || null,
+                  uploadTime: it.dataset?.uploadTime || null
+                }));
+                const lmList = metaCandidates.map(m => m.lastModified).filter(Boolean).sort();
+                const utList = metaCandidates.map(m => m.uploadTime).filter(Boolean).sort();
+                const lastModified = lmList.length ? lmList.slice(-1)[0] : new Date().toISOString();
+                const uploadTime = utList.length ? utList[0] : new Date().toISOString();
+                const newMeta = { lastModified, uploadTime };
+                await this.stateManager.saveMeta(newMeta);
+              }
+            } catch (e) {
+              // ignore
+            }
+          })();
         }
-      } catch (e) {
-        // ignore
-      }
-    })();
       }
     }
   }

--- a/lib/playlistTool.js
+++ b/lib/playlistTool.js
@@ -210,24 +210,29 @@ export const getandUpdatePlaylistState = (sharedState) => {
     // compute playlist-level metadata from DOM dataset (not saved inside each item)
     let lastModified = null;
     let uploadTime = null;
+    let hasItems = sharedState.playlistItems && sharedState.playlistItems.length > 0;
     try {
-        const metaCandidates = sharedState.playlistItems.map(it => ({
+        const metaCandidates = (sharedState.playlistItems || []).map(it => ({
             lastModified: it.dataset?.lastModified || null,
             uploadTime: it.dataset?.uploadTime || null
         }));
-        const lmList = metaCandidates.map(m => m.lastModified).filter(Boolean).sort();
-        lastModified = lmList.length ? lmList.slice(-1)[0] : null;
-        const utList = metaCandidates.map(m => m.uploadTime).filter(Boolean).sort();
-        uploadTime = utList.length ? utList[0] : null;
+        if (metaCandidates.length) {
+            const lmList = metaCandidates.map(m => m.lastModified).filter(Boolean).sort();
+            lastModified = lmList.length ? lmList.slice(-1)[0] : null;
+            const utList = metaCandidates.map(m => m.uploadTime).filter(Boolean).sort();
+            uploadTime = utList.length ? utList[0] : null;
+        }
     } catch (e) {
         // ignore
     }
 
     if (!equalsCheck(sharedState.state, nowPlaylistState)) {
         console.debug('Playlist State:', nowPlaylistState);
-        // send items and meta separately
-        const meta = { lastModified: lastModified || new Date().toISOString(), uploadTime: uploadTime || new Date().toISOString() };
-        sendPlaylistStateToBackground(nowPlaylistState, meta);
+        if (hasItems) {
+            // send items and meta separately
+            const meta = { lastModified: lastModified || new Date().toISOString(), uploadTime: uploadTime || new Date().toISOString() };
+            sendPlaylistStateToBackground(nowPlaylistState, meta);
+        }
     }
     return nowPlaylistState;
 };

--- a/lib/sendPlaylistStateToBackground.js
+++ b/lib/sendPlaylistStateToBackground.js
@@ -4,7 +4,7 @@ import { getCurrentVideoId } from './getVideoInfo.js';
  * 將播放列表狀態傳送到 background.js 進行紀錄。
  * @param {PlaylistState} nowPlaylistState - 現在狀態的播放列表。
  */
-export function sendPlaylistStateToBackground(nowPlaylistState, meta = {}) {
+export function sendPlaylistStateToBackground(nowPlaylistState, meta) {
     const videoId = getCurrentVideoId();
     if (!videoId) {
         console.debug('No video ID found.');
@@ -13,9 +13,9 @@ export function sendPlaylistStateToBackground(nowPlaylistState, meta = {}) {
 
     const playlistData = {
         videoId: videoId,
-        state: nowPlaylistState,
-        meta: meta
+        state: nowPlaylistState
     };
+    if (meta) playlistData.meta = meta;
 
     chrome.runtime.sendMessage({ action: 'updatePlaylistState', data: playlistData }, response => {
         if (response && response.success) {

--- a/lib/stateManager.js
+++ b/lib/stateManager.js
@@ -37,9 +37,15 @@ export class PlaylistStateManager {
             await chrome.storage.local.set({ [this.storageKey]: this.state, [this.metaKey]: newMeta });
         }
 
-        // Ensure meta exists (create default if not present)
+        // Ensure meta state is consistent with items
         const metaResult = await chrome.storage.local.get(this.metaKey);
-        if (!metaResult[this.metaKey]) {
+        if (this.state.length === 0) {
+            // no timeline items -> remove any existing meta
+            if (metaResult[this.metaKey]) {
+                await chrome.storage.local.remove(this.metaKey);
+            }
+        } else if (!metaResult[this.metaKey]) {
+            // have items but missing meta -> create with current timestamp
             const now2 = new Date().toISOString();
             await chrome.storage.local.set({ [this.metaKey]: { lastModified: now2, uploadTime: now2 } });
         }
@@ -61,6 +67,11 @@ export class PlaylistStateManager {
 
     async saveMeta(meta) {
         if (!this.videoId) return;
+        // if no items or no meta provided, remove existing meta entry
+        if (!meta || !Array.isArray(this.state) || this.state.length === 0) {
+            await chrome.storage.local.remove(this.metaKey);
+            return;
+        }
         await chrome.storage.local.set({ [this.metaKey]: meta });
     }
 

--- a/readme.md
+++ b/readme.md
@@ -53,7 +53,7 @@ Handles runtime messages and manages the state of the extension (on/off) and pla
 ### sendPlaylistStateToBackground.js
 Sends the current playlist state to the background script for persistence.
 - **Functions**:
-  - `sendPlaylistStateToBackground(nowPlaylistState)`: Sends the current playlist state to `background.js`.
+  - `sendPlaylistStateToBackground(nowPlaylistState, meta)`: Sends the current playlist state to `background.js` with optional metadata.
 
 ### getVideoInfo.js
 Provides functions to retrieve information about the current YouTube video.


### PR DESCRIPTION
## Summary
- Prevent creation of upload/modified metadata when no playlist items exist
- Send playlist metadata to background only when timelines are present
- Remove stored playlist and metadata when all items are deleted

## Testing
- `npm test` *(fails: package.json not found)*
- `node --check lib/stateManager.js`
- `node --check lib/sendPlaylistStateToBackground.js`
- `node --check lib/playlistTool.js`
- `node --check lib/mouseEventHandler.js`


------
https://chatgpt.com/codex/tasks/task_e_68b215cc80088328a51599a92f163e0b