### PR TITLE
Fix playlist creation when times are null

### DIFF
--- a/content.js
+++ b/content.js
@@ -425,7 +425,7 @@
      */
     function createPlaylistItem(startTime, endTime, title, meta) {
         // 確認起訖時間是否合法，若不合法則自動修正
-        if (startTime !== undefined && endTime !== undefined) {
+        if (startTime != null && endTime != null) {
             const timeObj  = PlaylistTimeManager.checkStartAndEnd(startTime, endTime);
             startTime = timeObj.start;
             endTime   = timeObj.end;

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -31,21 +31,17 @@ export function createPlaylistItemsContainer() {
 }
 
 export function createTimeTextElements(startTime = null, endTime = null) {
-    let startObj, endObj;
-
-    if (startTime !== null) {
-        const startAndEndTimeObj = PlaylistTimeManager.checkStartAndEnd(startTime, endTime);
-        startObj = startAndEndTimeObj['start'];
-        endObj = startAndEndTimeObj['end'];
-    } else {
-        startObj = getCurrentVideoTime();
-        endObj = getCurrentVideoTime();
-    }
+    let startObj = startTime ?? getCurrentVideoTime();
+    let endObj = endTime ?? getCurrentVideoTime();
 
     if (!startObj || !endObj) {
         console.error('No video element found.');
         return null;
     }
+
+    const timeObj = PlaylistTimeManager.checkStartAndEnd(startObj, endObj);
+    startObj = timeObj.start;
+    endObj = timeObj.end;
 
     const startItemText = document.createElement('div');
     startItemText.classList.add('ytj-playlist-item-text-start');


### PR DESCRIPTION
## Summary
- prevent TypeError when creating playlist items with null start/end times
- ensure time text elements derive & validate start/end times correctly

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2190d93908328b0c13ccd78e19aa3