### PR TITLE
Expand popup playlists inline

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -101,10 +101,9 @@
             margin: 8px 0;
             padding: 12px;
             border-radius: 10px;
-            display:flex;
-            align-items:center;
-            justify-content:space-between;
-            gap:12px;
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
         }
         .playlist-title {
             font-weight: 600;

--- a/popup.js
+++ b/popup.js
@@ -115,6 +115,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         top.style.display = 'flex';
         top.style.width = '100%';
         top.style.alignItems = 'center';
+        top.style.justifyContent = 'space-between';
 
         const left = document.createElement('div');
         left.style.flex = '1';


### PR DESCRIPTION
## Summary
- Show each playlist's timeline inline in the popup
- Align playlist header elements with flex for clearer layout

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b22863f1008328a07c79c6ad1e12e4