### PR TITLE
Refine popup timeline expand behavior

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -193,6 +193,39 @@
             background: var(--card);
             color: #e6eef6;
         }
+        .playlist-expand{
+            text-align:center;
+            cursor:pointer;
+            padding:4px 0;
+            font-size:12px;
+            color: var(--muted);
+            border-top:1px solid rgba(255,255,255,0.04);
+        }
+        .playlist-details{
+            margin-top:8px;
+            padding-top:8px;
+            border-top:1px solid rgba(255,255,255,0.03);
+        }
+        .playlist-details ul{
+            list-style:none;
+            padding:0;
+            margin:0;
+        }
+        .timeline-entry{
+            display:flex;
+            align-items:center;
+            gap:6px;
+            padding:4px 0;
+            font-size:12px;
+        }
+        .timeline-start,
+        .timeline-end{
+            width:60px;
+            flex-shrink:0;
+        }
+        .timeline-title{
+            flex:1;
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Add dedicated expand bar under each playlist so the entire header is no longer clickable
- Mirror YouTube-style timeline layout with separate start/end columns and title
- Allow clicking playlist titles to open videos directly

## Testing
- `node --check popup.js`
- `npm test` *(fails: ENOENT could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b22a28ef908328bc241e5185b79df5