### PR TITLE
feat: remove open button and complete i18n

### DIFF
--- a/_locales/123/messages.json
+++ b/_locales/123/messages.json
@@ -31,9 +31,25 @@
     "message": "個時間點",
     "description": "時間點數量後綴"
   },
-  "open_video": {
-    "message": "打開影片",
-    "description": "打開影片按鈕"
+  "search_placeholder": {
+    "message": "搜尋...",
+    "description": "搜尋欄位的預設文字"
+  },
+  "sort_lastModified_desc": {
+    "message": "最後修改時間 ↓",
+    "description": "排序選項：最後修改時間(新到舊)"
+  },
+  "sort_lastModified_asc": {
+    "message": "最後修改時間 ↑",
+    "description": "排序選項：最後修改時間(舊到新)"
+  },
+  "sort_uploadTime_desc": {
+    "message": "上傳時間 ↓",
+    "description": "排序選項：上傳時間(新到舊)"
+  },
+  "sort_uploadTime_asc": {
+    "message": "上傳時間 ↑",
+    "description": "排序選項：上傳時間(舊到新)"
   },
   "no_empty_playlists": {
     "message": "沒有可清除的空播放清單。",

--- a/_locales/zh-TW/messages.json
+++ b/_locales/zh-TW/messages.json
@@ -31,9 +31,25 @@
     "message": "個時間點",
     "description": "時間點數量後綴"
   },
-  "open_video": {
-    "message": "打開影片",
-    "description": "打開影片按鈕"
+  "search_placeholder": {
+    "message": "搜尋...",
+    "description": "搜尋欄位的預設文字"
+  },
+  "sort_lastModified_desc": {
+    "message": "最後修改時間 ↓",
+    "description": "排序選項：最後修改時間(新到舊)"
+  },
+  "sort_lastModified_asc": {
+    "message": "最後修改時間 ↑",
+    "description": "排序選項：最後修改時間(舊到新)"
+  },
+  "sort_uploadTime_desc": {
+    "message": "上傳時間 ↓",
+    "description": "排序選項：上傳時間(新到舊)"
+  },
+  "sort_uploadTime_asc": {
+    "message": "上傳時間 ↑",
+    "description": "排序選項：上傳時間(舊到新)"
   },
   "no_empty_playlists": {
     "message": "沒有可清除的空播放清單。",

--- a/_locales/zh/messages.json
+++ b/_locales/zh/messages.json
@@ -31,9 +31,25 @@
     "message": "timepoints",
     "description": "Suffix after number of timepoints"
   },
-  "open_video": {
-    "message": "Open video",
-    "description": "Open video button"
+  "search_placeholder": {
+    "message": "Search...",
+    "description": "Default text in search box"
+  },
+  "sort_lastModified_desc": {
+    "message": "Last modified ↓",
+    "description": "Sort option: last modified (newest first)"
+  },
+  "sort_lastModified_asc": {
+    "message": "Last modified ↑",
+    "description": "Sort option: last modified (oldest first)"
+  },
+  "sort_uploadTime_desc": {
+    "message": "Upload time ↓",
+    "description": "Sort option: upload time (newest first)"
+  },
+  "sort_uploadTime_asc": {
+    "message": "Upload time ↑",
+    "description": "Sort option: upload time (oldest first)"
   },
   "no_empty_playlists": {
     "message": "No empty playlists to remove.",

--- a/popup.html
+++ b/popup.html
@@ -114,9 +114,6 @@
             font-size: 12px;
             color: var(--muted);
         }
-        .playlist-meta{
-            text-align:right;
-        }
         .button-container {
             margin-top: 8px;
             display: flex;
@@ -131,13 +128,6 @@
             cursor: pointer;
             font-weight:600;
             box-shadow: 0 6px 14px rgba(59,130,246,0.12);
-        }
-        button.secondary{
-            background: transparent;
-            border: 1px solid rgba(255,255,255,0.06);
-            color: var(--muted);
-            box-shadow: none;
-            font-weight:500;
         }
         button.third {
             padding: 8px 12px;
@@ -246,12 +236,12 @@
     </div>
 
     <div class="button-container controls" style="margin-top:6px; gap:6px; align-items:center;">
-        <input id="searchInput" type="search" placeholder="Search..." style="flex:1; padding:8px; border-radius:8px; border:1px solid rgba(255,255,255,0.04); background:transparent; color:inherit;">
+        <input id="searchInput" type="search" data-i18n-placeholder="search_placeholder" placeholder="__MSG_search_placeholder__" style="flex:1; padding:8px; border-radius:8px; border:1px solid rgba(255,255,255,0.04); background:transparent; color:inherit;">
         <select id="sortSelect" style="padding:8px; border-radius:8px; border:1px solid rgba(255,255,255,0.04); color:inherit;">
-            <option value="lastModified_desc" selected>Last modified ↓</option>
-            <option value="lastModified_asc">Last modified ↑</option>
-            <option value="uploadTime_desc">Upload time ↓</option>
-            <option value="uploadTime_asc">Upload time ↑</option>
+            <option value="lastModified_desc" selected data-i18n="sort_lastModified_desc">__MSG_sort_lastModified_desc__</option>
+            <option value="lastModified_asc" data-i18n="sort_lastModified_asc">__MSG_sort_lastModified_asc__</option>
+            <option value="uploadTime_desc" data-i18n="sort_uploadTime_desc">__MSG_sort_uploadTime_desc__</option>
+            <option value="uploadTime_asc" data-i18n="sort_uploadTime_asc">__MSG_sort_uploadTime_asc__</option>
         </select>
     </div>
     <div class="playlist-container" id="playlistContainer">

--- a/popup.js
+++ b/popup.js
@@ -9,6 +9,15 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
     });
 
+    document.querySelectorAll('[data-i18n-placeholder]').forEach(el => {
+        const key = el.getAttribute('data-i18n-placeholder');
+        try {
+            el.placeholder = chrome.i18n.getMessage(key) || el.placeholder;
+        } catch (e) {
+            // ignore
+        }
+    });
+
     const playlistContainer = document.getElementById('playlistContainer');
     const importBtn = document.getElementById('importBtn');
     const exportBtn = document.getElementById('exportBtn');
@@ -122,7 +131,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         const titleDiv = document.createElement('div');
         titleDiv.className = 'playlist-title';
-        titleDiv.textContent = title || `影片 ID: ${videoId}`;
+        titleDiv.textContent = title || `${chrome.i18n.getMessage('video_id_prefix')} ${videoId}`;
         // allow clicking title to open video like YouTube page
         titleDiv.style.cursor = 'pointer';
         titleDiv.addEventListener('click', (e) => {
@@ -137,19 +146,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         left.appendChild(titleDiv);
         left.appendChild(infoDiv);
 
-        const meta = document.createElement('div');
-        meta.className = 'playlist-meta';
-        const openBtn = document.createElement('button');
-        openBtn.className = 'secondary';
-        openBtn.textContent = chrome.i18n.getMessage('open_video');
-        openBtn.addEventListener('click', (e) => {
-            e.stopPropagation();
-            chrome.tabs.create({ url: `https://www.youtube.com/watch?v=${videoId}` });
-        });
-        meta.appendChild(openBtn);
-
         top.appendChild(left);
-        top.appendChild(meta);
         itemDiv.appendChild(top);
 
         // expandable area placed under the title (full width)


### PR DESCRIPTION
## Summary
- drop unused open video button in popup and simplify playlist entries
- add i18n support for search placeholder and sort options
- provide localized strings for new UI text in existing locale files

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b22fb50910832896c6d91837e6c2fe