### PR TITLE
refactor: migrate playlist storage

### DIFF
--- a/content.js
+++ b/content.js
@@ -188,8 +188,14 @@
             return;
         }
 
-        const result = await chrome.storage.local.get(videoId);
-        const savedState = result[videoId];
+        let savedState;
+        const store = await chrome.storage.local.get('playlistStates');
+        if (store.playlistStates && store.playlistStates[videoId]) {
+            savedState = store.playlistStates[videoId];
+        } else {
+            const legacy = await chrome.storage.local.get(videoId);
+            savedState = legacy[videoId];
+        }
         if (Array.isArray(savedState)) {
             savedState.forEach(itemData => {
                 const startTime = TimeSlot.fromObject(itemData.start);


### PR DESCRIPTION
## Summary
- consolidate playlist storage under playlistStates and add migration for pre-2.0 installs
- read playlists from new structure with legacy fallback

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2370d83008328b1a72994bd764556