### PR TITLE
feat: append imported playlists instead of overwriting

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,7 @@ This project is a Chrome extension designed to enhance YouTube's playlist manage
 ## Features
 - **Dark Theme Detection**: Automatically apply the correct CSS theme based on YouTube's dark or light theme.
 - **Playlist Management**: Add, edit, and delete items in your custom playlists.
+- **Playlist Import**: Importing playlists now appends timelines to existing ones instead of overwriting them.
 - **Video Info Retrieval**: Get the current video ID and playtime.
 - **State Management**: Synchronize and update the playlist state with the background script.
 - **User Interaction**: Enable editable text fields and handle drag-and-drop for playlist items.


### PR DESCRIPTION
## Summary
- merge imported playlist timelines with existing storage data
- document that importing playlists appends timelines instead of overwriting

## Testing
- `node --check popup.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b23c0d8b208328900a1b931f2d0528